### PR TITLE
Update history table columns

### DIFF
--- a/gym_managementservice_frontend/src/components/EntryHistoryTable.jsx
+++ b/gym_managementservice_frontend/src/components/EntryHistoryTable.jsx
@@ -52,7 +52,12 @@ const COLUMN_DEFINITIONS = {
  * @param {boolean} [props.showTotal=true] - Určuje, zda se má zobrazit celkový počet vstupů v zápatí.
  * @returns {JSX.Element} Tabulka s historií vstupů.
  */
-function EntryHistoryTable({ entries, formatDate, columns, showTotal }) {
+function EntryHistoryTable({
+    entries,
+    formatDate,
+    columns = ['date', 'userName', 'subscriptionType'],
+    showTotal = true,
+}) {
     /**
      * Vypočítá celkový počet vstupů.
      * @type {number}
@@ -109,9 +114,5 @@ EntryHistoryTable.propTypes = {
     showTotal: PropTypes.bool,
 };
 
-EntryHistoryTable.defaultProps = {
-    columns: ['date', 'userName', 'subscriptionType'],
-    showTotal: true,
-};
 
 export default EntryHistoryTable;

--- a/gym_managementservice_frontend/src/components/SummaryCard.jsx
+++ b/gym_managementservice_frontend/src/components/SummaryCard.jsx
@@ -8,7 +8,7 @@ import styles from './SummaryCard.module.css';
  * SummaryCard zobrazí stručnou metrickou kartu s ikonou, názvem a hodnotou.
  * @param {{ title: string, value: string | number, icon: React.ComponentType }} props
  */
-export default function SummaryCard({ title, value, icon: Icon }) {
+export default function SummaryCard({ title, value, icon: Icon = null }) {
     return (
         <motion.div
             className={styles.card}
@@ -31,6 +31,3 @@ SummaryCard.propTypes = {
     icon: PropTypes.elementType,
 };
 
-SummaryCard.defaultProps = {
-    icon: null,
-};

--- a/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
+++ b/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
@@ -70,7 +70,12 @@ const COLUMN_DEFINITIONS = {
  * @param {boolean} [props.showTotal=true] - Určuje, zda se má zobrazit součet všech transakcí.
  * @returns {JSX.Element} Tabulka s historií transakcí.
  */
-function TransactionHistoryTable({ transactions, formatDate, columns, showTotal }) {
+function TransactionHistoryTable({
+    transactions,
+    formatDate,
+    columns = ['date', 'userName', 'purchaseType', 'amount'],
+    showTotal = true,
+}) {
     /**
      * Vypočítá celkovou cenu ze všech transakcí.
      * @type {number}
@@ -126,9 +131,5 @@ TransactionHistoryTable.propTypes = {
     showTotal: PropTypes.bool,
 };
 
-TransactionHistoryTable.defaultProps = {
-    columns: ['date', 'userName', 'purchaseType', 'amount'],
-    showTotal: true,
-};
 
 export default TransactionHistoryTable;

--- a/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
+++ b/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
@@ -48,14 +48,14 @@ const COLUMN_DEFINITIONS = {
          */
         render: (tx) => `${tx.amount} Kč`,
     },
-    note: {
+    description: {
         header: 'Popis (poznámka)',
         /**
          * Renderuje poznámku k transakci nebo "-" pokud není k dispozici.
          * @param {Object} tx - Objekt transakce.
          * @returns {string} Poznámka k transakci.
          */
-        render: (tx) => tx.note || '-',
+        render: (tx) => tx.description || '-',
     },
 };
 
@@ -73,7 +73,7 @@ const COLUMN_DEFINITIONS = {
 function TransactionHistoryTable({
     transactions,
     formatDate,
-    columns = ['date', 'userName', 'purchaseType', 'amount'],
+    columns = ['date', 'userName', 'purchaseType', 'amount','description'],
     showTotal = true,
 }) {
     /**

--- a/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
+++ b/gym_managementservice_frontend/src/components/TransactionHistoryTable.jsx
@@ -49,7 +49,7 @@ const COLUMN_DEFINITIONS = {
         render: (tx) => `${tx.amount} Kč`,
     },
     note: {
-        header: 'Poznámka',
+        header: 'Popis (poznámka)',
         /**
          * Renderuje poznámku k transakci nebo "-" pokud není k dispozici.
          * @param {Object} tx - Objekt transakce.

--- a/gym_managementservice_frontend/src/pages/ShowUserHistoryPage.jsx
+++ b/gym_managementservice_frontend/src/pages/ShowUserHistoryPage.jsx
@@ -191,6 +191,7 @@ export default function ShowHistoryPage() {
                     <TransactionHistoryTable
                         transactions={transactions}
                         formatDate={fmt}
+                        columns={['date', 'note', 'amount']}
                     />
                 </div>
             </div>

--- a/gym_managementservice_frontend/src/pages/ShowUserHistoryPage.jsx
+++ b/gym_managementservice_frontend/src/pages/ShowUserHistoryPage.jsx
@@ -74,6 +74,7 @@ export default function ShowHistoryPage() {
                 eRes = await api.get(`/entry-history/user/${id}`);
                 tRes = await api.get(`/transaction-history/user/${id}`);
 
+
                 // uložíme první a poslední vstup jednou
                 if (!firstEntryDateStatic && eRes.data.length > 0) {
                     setFirstEntryDateStatic(fmt(eRes.data[0].entryDate || eRes.data[0].date));
@@ -88,6 +89,9 @@ export default function ShowHistoryPage() {
                     params: { userId: id, start: startIso, end: endIso }
                 });
             }
+            // tady si to vypíšeš do konzole
+            console.log('eRes:', eRes);
+            console.log('tRes:', tRes);
             setEntries(eRes.data);
             setTransactions(tRes.data);
         } finally {
@@ -191,7 +195,7 @@ export default function ShowHistoryPage() {
                     <TransactionHistoryTable
                         transactions={transactions}
                         formatDate={fmt}
-                        columns={['date', 'note', 'amount']}
+                        columns={['date', 'description', 'amount']}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- change default note column header to "Popis (poznámka)"
- in `ShowUserHistoryPage`, show date, description and price columns in transaction history

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869337235308333935f6061f74c75db