### PR TITLE
Add manual one-time entry support

### DIFF
--- a/gym_managementservice_frontend/src/pages/ChargeOneTimeEntry.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeOneTimeEntry.jsx
@@ -8,13 +8,9 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-
-import api from '../services/api';
-import { formatDate } from '../utils/dateUtils';
+import { chargeOneTimeEntry, STANDARD_ENTRY_ID } from '../utils/oneTimeEntryUtils';
 import UserIdentifier from '../components/UserIdentifier';
 
-/** ID definice standardního jednorázového vstupu na backendu. */
-const STANDARD_ENTRY_ID = 1;
 
 /**
  * Renders only the {@link UserIdentifier} modal. Once the user is found
@@ -29,17 +25,7 @@ export default function ChargeOneTimeEntry() {
 
         const chargeEntry = async () => {
             try {
-                const purchaseDate = new Date().toISOString().split('T')[0];
-                await api.post(
-                    '/user-one-time-entries',
-                    {
-                        userID: userId,
-                        oneTimeEntryID: STANDARD_ENTRY_ID,
-                        purchaseDate,
-                        isUsed: false
-                    },
-                    { params: { count: 1 } }
-                );
+                await chargeOneTimeEntry(userId, STANDARD_ENTRY_ID, 1);
                 toast.success('Jednorázový vstup úspěšně dobit.');
             } catch (err) {
                 console.error(err);

--- a/gym_managementservice_frontend/src/pages/ChargeOneTimeEntryStudent.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeOneTimeEntryStudent.jsx
@@ -9,12 +9,9 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
-import api from '../services/api';
-import { formatDate } from '../utils/dateUtils';
+import { chargeOneTimeEntry, STUDENT_ENTRY_ID } from '../utils/oneTimeEntryUtils';
 import UserIdentifier from '../components/UserIdentifier';
 
-/** ID definice studentského jednorázového vstupu na backendu. */
-const STUDENT_ENTRY_ID = 2;
 
 /**
  * Renders the {@link UserIdentifier} modal and after a user is found charges a
@@ -29,17 +26,7 @@ export default function ChargeOneTimeEntryStudent() {
 
         const chargeEntry = async () => {
             try {
-                const purchaseDate = new Date().toISOString().split('T')[0];
-                await api.post(
-                    '/user-one-time-entries',
-                    {
-                        userID: userId,
-                        oneTimeEntryID: STUDENT_ENTRY_ID,
-                        purchaseDate,
-                        isUsed: false
-                    },
-                    { params: { count: 1 } }
-                );
+                await chargeOneTimeEntry(userId, STUDENT_ENTRY_ID, 1);
                 toast.success('Studentský vstup úspěšně dobit.');
             } catch (err) {
                 console.error(err);

--- a/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
@@ -9,6 +9,7 @@ import styles from './ChargeSubscription.module.css';
 import api from '../services/api';
 import useChargeSubscription from '../hooks/useChargeSubscription';
 import { formatDate } from '../utils/dateUtils';
+import { chargeOneTimeEntry } from '../utils/oneTimeEntryUtils';
 
 import SimpleButton from '../components/SimpleButton';
 import SimpleModal from '../components/SimpleModal';
@@ -133,19 +134,10 @@ function ChargeSubscription() {
             // (B) Dobití jednorázových vstupů
         } else if (modalAction === 'onetimes' && selectedOneTimeEntry) {
             try {
-                const purchaseDate = new Date().toISOString().split('T')[0];
-                await api.post(
-                    '/user-one-time-entries',
-                    {
-                        userID: userId,
-                        oneTimeEntryID: selectedOneTimeEntry.oneTimeEntryID,
-                        purchaseDate,
-                        isUsed: false
-                    },
-                    {
-                        // count = kolikrát se má dokoupit
-                        params: { count: oneTimeToAdd }
-                    }
+                await chargeOneTimeEntry(
+                    userId,
+                    selectedOneTimeEntry.oneTimeEntryID,
+                    oneTimeToAdd
                 );
                 toast.success(`Dobito ${oneTimeToAdd} vstupů, cena: ${modalPrice} Kč`);
                 setOneTimeToAdd(1); // Vrátíme na 1

--- a/gym_managementservice_frontend/src/pages/ManualCharge.jsx
+++ b/gym_managementservice_frontend/src/pages/ManualCharge.jsx
@@ -4,6 +4,7 @@ import styles from './ManualCharge.module.css';
 
 import api from '../services/api';
 import useChargeSubscription from '../hooks/useChargeSubscription';
+import { chargeOneTimeEntry, MANUAL_ENTRY_ID } from '../utils/oneTimeEntryUtils';
 
 import UserInfoBox from '../components/UserInfoBox';
 import SimpleButton from '../components/SimpleButton';
@@ -21,6 +22,8 @@ function ManualCharge() {
 
     const [customEndDate, setCustomEndDate] = useState('');
     const [customPrice, setCustomPrice] = useState(0);
+    const [manualEntryCount, setManualEntryCount] = useState(0);
+    const [manualEntryPrice, setManualEntryPrice] = useState(0);
 
     useEffect(() => {
         if (error) toast.error(error);
@@ -35,6 +38,10 @@ function ManualCharge() {
             toast.warn('Cena nemůže být záporná.');
             return;
         }
+        if (manualEntryPrice < 0 || manualEntryCount < 0) {
+            toast.warn('Počet ani cena manuálních vstupů nemůže být záporná.');
+            return;
+        }
         try {
             const today = new Date().toISOString().slice(0, 10);
             await api.post('/user-subscriptions', {
@@ -46,6 +53,16 @@ function ManualCharge() {
                 customEndDate,
                 customPrice
             });
+
+            if (manualEntryCount > 0) {
+                await chargeOneTimeEntry(
+                    userId,
+                    MANUAL_ENTRY_ID,
+                    manualEntryCount,
+                    manualEntryPrice
+                );
+            }
+
             toast.success('Předplatné úspěšně dobito.');
         } catch (err) {
             console.error(err);
@@ -104,6 +121,28 @@ function ManualCharge() {
                             min="0"
                             step="1"
                             onChange={(e) => setCustomPrice(Number(e.target.value))}
+                        />
+                    </div>
+                    <div className={styles.inputGroup}>
+                        <label htmlFor="manualCount">Počet manuálních vstupů:</label>
+                        <input
+                            id="manualCount"
+                            type="number"
+                            value={manualEntryCount}
+                            min="0"
+                            step="1"
+                            onChange={(e) => setManualEntryCount(Number(e.target.value))}
+                        />
+                    </div>
+                    <div className={styles.inputGroup}>
+                        <label htmlFor="manualPrice">Cena manuálního vstupu (Kč):</label>
+                        <input
+                            id="manualPrice"
+                            type="number"
+                            value={manualEntryPrice}
+                            min="0"
+                            step="1"
+                            onChange={(e) => setManualEntryPrice(Number(e.target.value))}
                         />
                     </div>
                     <SimpleButton text="Potvrdit" onClick={handleConfirm} />

--- a/gym_managementservice_frontend/src/utils/oneTimeEntryUtils.js
+++ b/gym_managementservice_frontend/src/utils/oneTimeEntryUtils.js
@@ -1,0 +1,24 @@
+export const STANDARD_ENTRY_ID = 1;
+export const STUDENT_ENTRY_ID = 2;
+export const MANUAL_ENTRY_ID = 3;
+
+import api from '../services/api';
+export async function chargeOneTimeEntry(
+    userID,
+    oneTimeEntryID,
+    count = 1,
+    customPrice = 0
+) {
+    const purchaseDate = new Date().toISOString().split('T')[0];
+    await api.post(
+        '/user-one-time-entries',
+        {
+            userID,
+            oneTimeEntryID,
+            purchaseDate,
+            isUsed: false,
+            customPrice
+        },
+        { params: { count } }
+    );
+}


### PR DESCRIPTION
## Summary
- add `MANUAL_ENTRY_ID` constant and custom price parameter
- extend `chargeOneTimeEntry` to accept custom prices
- allow manual charge page to top up manual one-time entries with amount and price

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ac30b9be88333895c329b474cfe4e