### PR TITLE
Add admin entry simulation page

### DIFF
--- a/gym_managementservice_frontend/src/App.jsx
+++ b/gym_managementservice_frontend/src/App.jsx
@@ -10,6 +10,7 @@ import ChargeSubscription from './pages/ChargeSubscription';
 import ManualCharge from './pages/ManualCharge';
 import ChargeOneTimeEntry from './pages/ChargeOneTimeEntry';
 import ChargeOneTimeEntryStudent from './pages/ChargeOneTimeEntryStudent';
+import AdminPage from './pages/AdminPage';
 
 import Header from './components/Header';
 import styles from './App.module.css';
@@ -49,6 +50,7 @@ function App() {
                     <Route path="/closure" element={<ClosurePage />} />
                     <Route path="/users/allUsers" element={<AllUsers />} />
                     <Route path="/manualCharge" element={<ManualCharge />} />
+                    <Route path="/admin" element={<AdminPage />} />
                     {/* ...další cesty... */}
 
                     <Route path="/page6" element={<ManualCharge />} />

--- a/gym_managementservice_frontend/src/pages/AdminPage.jsx
+++ b/gym_managementservice_frontend/src/pages/AdminPage.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import { toast } from 'react-toastify';
+import api from '../services/api';
+import styles from './AdminPage.module.css';
+
+function AdminPage() {
+    const [users, setUsers] = useState([]);
+    const [selectedUser, setSelectedUser] = useState('');
+    const [cardNumber, setCardNumber] = useState('');
+
+    useEffect(() => {
+        const fetchUsers = async () => {
+            try {
+                const resp = await api.get('/users');
+                setUsers(resp.data || []);
+            } catch (err) {
+                console.error(err);
+                toast.error('Nepodařilo se načíst uživatele.');
+            }
+        };
+        fetchUsers();
+    }, []);
+
+    const handleUserSubmit = async (e) => {
+        e.preventDefault();
+        if (!selectedUser) {
+            toast.warn('Vyberte uživatele.');
+            return;
+        }
+        try {
+            const resp = await api.get(`/validateEntryByUserID/${selectedUser}`);
+            toast.success(resp.data?.message || 'Vstup povolen.');
+        } catch (err) {
+            const msg = err.response?.data?.message || 'Vstup odepřen.';
+            toast.error(msg);
+        }
+    };
+
+    const handleCardSubmit = async (e) => {
+        e.preventDefault();
+        if (!cardNumber) {
+            toast.warn('Zadejte číslo karty.');
+            return;
+        }
+        try {
+            const resp = await api.get(`/validateEntryByCardNumber/${cardNumber}`);
+            toast.success(resp.data?.message || 'Vstup povolen.');
+        } catch (err) {
+            const msg = err.response?.data?.message || 'Vstup odepřen.';
+            toast.error(msg);
+        }
+    };
+
+    return (
+        <div className={styles.adminPageContainer}>
+            <h2>Simulace vstupu do posilovny</h2>
+            <div className={styles.modulesContainer}>
+                <form className={styles.module} onSubmit={handleUserSubmit}>
+                    <h3>Vstup podle uživatele</h3>
+                    <select
+                        value={selectedUser}
+                        onChange={(e) => setSelectedUser(e.target.value)}
+                    >
+                        <option value="">Vyberte uživatele</option>
+                        {users.map((u) => (
+                            <option key={u.userID} value={u.userID}>
+                                {u.firstname} {u.lastname}
+                            </option>
+                        ))}
+                    </select>
+                    <button type="submit">Vstoupit</button>
+                </form>
+
+                <form className={styles.module} onSubmit={handleCardSubmit}>
+                    <h3>Vstup podle čísla karty</h3>
+                    <input
+                        type="text"
+                        value={cardNumber}
+                        onChange={(e) => setCardNumber(e.target.value)}
+                        placeholder="Číslo karty"
+                    />
+                    <button type="submit">Vstoupit</button>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default AdminPage;

--- a/gym_managementservice_frontend/src/pages/AdminPage.module.css
+++ b/gym_managementservice_frontend/src/pages/AdminPage.module.css
@@ -1,0 +1,45 @@
+.adminPageContainer {
+    width: 80%;
+    max-width: 600px;
+    margin: 6rem auto;
+    padding: 2rem;
+    background-color: var(--main-content-background);
+    border-radius: 8px;
+    color: #fff;
+}
+
+.modulesContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.module {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    background-color: var(--component-background);
+    padding: 1rem;
+    border-radius: 6px;
+}
+
+.module select,
+.module input {
+    padding: 0.6rem;
+    border-radius: 4px;
+    border: 1px solid #646cff;
+    background-color: #2a2a2a;
+    color: #fff;
+}
+
+.module button {
+    padding: 0.6rem 1rem;
+    background-color: var(--button-background);
+    color: #fff;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.module button:hover {
+    background-color: var(--button-background-hover);
+}


### PR DESCRIPTION
## Summary
- create `AdminPage` for entry validation simulation
- style admin page
- register `/admin` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bc7342b04833392f9c1b284b863b4