### PR TITLE
Implement EntryStatusPage route

### DIFF
--- a/gym_managementservice_frontend/package-lock.json
+++ b/gym_managementservice_frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^6.4.1",
         "@mui/x-date-pickers": "^7.27.3",
         "@mui/x-date-pickers-pro": "^7.27.3",
+        "@stomp/stompjs": "^7.1.1",
         "axios": "^1.7.9",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
@@ -26,7 +27,8 @@
         "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.1",
         "react-toastify": "^11.0.3",
-        "react-transition-group": "^4.4.5"
+        "react-transition-group": "^4.4.5",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -2135,6 +2137,12 @@
         "win32"
       ]
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
+      "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3420,6 +3428,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3440,6 +3457,18 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3835,6 +3864,12 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3870,6 +3905,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4865,6 +4906,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5073,6 +5120,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -5158,6 +5211,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -5350,6 +5423,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map": {
@@ -5682,6 +5783,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.6.tgz",
@@ -5752,6 +5863,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/gym_managementservice_frontend/package.json
+++ b/gym_managementservice_frontend/package.json
@@ -29,7 +29,7 @@
     "react-router-dom": "^7.1.1",
     "react-toastify": "^11.0.3",
     "react-transition-group": "^4.4.5",
-    "@stomp/stompjs": "^7.1.2",
+    "@stomp/stompjs": "^7.1.1",
     "sockjs-client": "^1.6.1"
   },
   "devDependencies": {

--- a/gym_managementservice_frontend/package.json
+++ b/gym_managementservice_frontend/package.json
@@ -28,7 +28,9 @@
     "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.1",
     "react-toastify": "^11.0.3",
-    "react-transition-group": "^4.4.5"
+    "react-transition-group": "^4.4.5",
+    "@stomp/stompjs": "^7.1.2",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/gym_managementservice_frontend/src/App.jsx
+++ b/gym_managementservice_frontend/src/App.jsx
@@ -19,6 +19,7 @@ import UserDetail from "./pages/UserDetail.jsx";
 import ClosurePage from "./pages/ClosurePage.jsx";
 import AllUsers from "./pages/AllUsers.jsx";
 import ShowHistoryPage from "./pages/ShowUserHistoryPage.jsx";
+import EntryStatusPage from "./pages/EntryStatusPage.jsx";
 
 function App() {
     return (
@@ -60,6 +61,7 @@ function App() {
                     <Route path="/users/:id" element={<UserDetail />} />
                     <Route path="/users/" element={<UserDetail />} />
                     <Route path="/users/:id/history" element={<ShowHistoryPage />} />
+                    <Route path="/entry-status" element={<EntryStatusPage />} />
                 </Routes>
             </div>
         </Router>

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+import styles from './EntryStatusPage.module.css';
+
+function EntryStatusPage() {
+    const clientRef = useRef(null);
+    const [status, setStatus] = useState(null);
+    const [remainingEntries, setRemainingEntries] = useState(null);
+    const [expiryDate, setExpiryDate] = useState(null);
+
+    useEffect(() => {
+        const socketUrl = `${import.meta.env.VITE_BACKEND_URL.replace('http', 'ws')}/ws-entry`;
+        const client = new Client({
+            webSocketFactory: () => new SockJS(socketUrl),
+            onConnect: () => {
+                client.subscribe('/topic/entry-status', (message) => {
+                    console.log(message.body);
+                    try {
+                        const data = JSON.parse(message.body);
+                        setStatus(data.status ?? null);
+                        setRemainingEntries(data.remainingEntries ?? null);
+                        setExpiryDate(data.expiryDate ?? null);
+                    } catch (err) {
+                        console.error('Invalid message:', err);
+                    }
+                });
+            },
+        });
+
+        client.activate();
+        clientRef.current = client;
+
+        return () => {
+            clientRef.current?.deactivate();
+        };
+    }, []);
+
+    return (
+        <div className={styles.container}>
+            {status === 'OK' && <h1>Vítejte!</h1>}
+            {remainingEntries != null && <p>Zbývá Vám {remainingEntries} vstupů</p>}
+            {expiryDate != null && <p>Předplatné vypršelo {expiryDate}</p>}
+            {status === null && remainingEntries === null && expiryDate === null && 'Loading…'}
+        </div>
+    );
+}
+
+export default EntryStatusPage;

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -1,3 +1,4 @@
+
 import React, { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
@@ -1,0 +1,9 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    min-height: 100vh;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add an `EntryStatusPage` placeholder component
- style it with full-screen centered layout
- register new `/entry-status` route in App
- connect EntryStatusPage to WebSocket endpoint `/ws-entry`
- log incoming messages from `/topic/entry-status`
- parse entry-status events and display status text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cdfa2ff98833380817d296f9ccae5