### PR TITLE
Improve entry status display

### DIFF
--- a/gym_managementservice_frontend/package-lock.json
+++ b/gym_managementservice_frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/x-date-pickers-pro": "^7.27.3",
         "@stomp/stompjs": "^7.1.1",
         "axios": "^1.7.9",
+        "czech-vocative": "^2.0.1",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "framer-motion": "^12.18.1",
@@ -2793,6 +2794,24 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/czech-vocative": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/czech-vocative/-/czech-vocative-2.0.1.tgz",
+      "integrity": "sha512-MH7SDCmKjucEa1OVdAQdMrl/0VekSKDZVh5qyCmXRY0g5yeNeoGJUwC5NMzAqHusjBNq0uof9JqwXhI13lhyhg==",
+      "license": "MIT",
+      "dependencies": {
+        "czech-vocative": "^1.0.0"
+      }
+    },
+    "node_modules/czech-vocative/node_modules/czech-vocative": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/czech-vocative/-/czech-vocative-1.0.1.tgz",
+      "integrity": "sha512-197JBab7de3y128xGKIxF28F8y0+PqfT6WPCOqOzcQD/PpfsZDyO7DX45m4SsZ3yH2qnuS8ISDTfsC0a2/cp3A==",
+      "license": "MIT",
+      "dependencies": {
+        "czech-vocative": "^1.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",

--- a/gym_managementservice_frontend/package.json
+++ b/gym_managementservice_frontend/package.json
@@ -16,7 +16,9 @@
     "@mui/material": "^6.4.1",
     "@mui/x-date-pickers": "^7.27.3",
     "@mui/x-date-pickers-pro": "^7.27.3",
+    "@stomp/stompjs": "^7.1.1",
     "axios": "^1.7.9",
+    "czech-vocative": "^2.0.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.18.1",
@@ -29,9 +31,7 @@
     "react-router-dom": "^7.1.1",
     "react-toastify": "^11.0.3",
     "react-transition-group": "^4.4.5",
-    "@stomp/stompjs": "^7.1.1",
-    "sockjs-client": "^1.6.1",
-    "osloveni": "^1.0.0"
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/gym_managementservice_frontend/package.json
+++ b/gym_managementservice_frontend/package.json
@@ -30,7 +30,8 @@
     "react-toastify": "^11.0.3",
     "react-transition-group": "^4.4.5",
     "@stomp/stompjs": "^7.1.1",
-    "sockjs-client": "^1.6.1"
+    "sockjs-client": "^1.6.1",
+    "osloveni": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -2,26 +2,23 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
+import { osloveni } from 'osloveni';
 import styles from './EntryStatusPage.module.css';
 
 function EntryStatusPage() {
     const clientRef = useRef(null);
-    const [status, setStatus] = useState(null);
-    const [remainingEntries, setRemainingEntries] = useState(null);
-    const [expiryDate, setExpiryDate] = useState(null);
+    const [message, setMessage] = useState(null);
 
     useEffect(() => {
         const socketUrl = `${import.meta.env.VITE_BACKEND_URL}/ws-entry`;
         const client = new Client({
             webSocketFactory: () => new SockJS(socketUrl),
             onConnect: () => {
-                client.subscribe('/topic/entry-status', (message) => {
-                    console.log(message.body);
+                client.subscribe('/topic/entry-status', (msg) => {
+                    console.log(msg.body);
                     try {
-                        const data = JSON.parse(message.body);
-                        setStatus(data.status ?? null);
-                        setRemainingEntries(data.remainingEntries ?? null);
-                        setExpiryDate(data.expiryDate ?? null);
+                        const data = JSON.parse(msg.body);
+                        setMessage(data);
                     } catch (err) {
                         console.error('Invalid message:', err);
                     }
@@ -37,14 +34,55 @@ function EntryStatusPage() {
         };
     }, []);
 
-    return (
-        <div className={styles.container}>
-            {status === 'OK' && <h1>Vítejte!</h1>}
-            {remainingEntries != null && <p>Zbývá Vám {remainingEntries} vstupů</p>}
-            {expiryDate != null && <p>Předplatné vypršelo {expiryDate}</p>}
-            {status === null && remainingEntries === null && expiryDate === null && 'Loading…'}
-        </div>
-    );
+    useEffect(() => {
+        if (!message) return;
+        const timer = setTimeout(() => setMessage(null), 5000);
+        return () => clearTimeout(timer);
+    }, [message]);
+
+    const renderContent = () => {
+        if (!message) {
+            return (
+                <h1 className={styles.chill}>
+                    MILANO<br />
+                    GYM
+                </h1>
+            );
+        }
+
+        const name = osloveni(message.firstname || '');
+
+        switch (message.status) {
+        case 'OK_SUBSCRIPTION':
+            return (
+                <>
+                    <h1>Vítejte {name},</h1>
+                    <h2>pěkně si zacvičte</h2>
+                    <p>Vaše předplatné je aktivní do: {message.expiryDate}</p>
+                </>
+            );
+        case 'OK_ONE_TIME_ENTRY':
+            return (
+                <>
+                    <h1>Vítejte {name},</h1>
+                    <h2>pěkně si zacvičte</h2>
+                    <p>Počet zbývajících vstupů: {message.remainingEntries}</p>
+                </>
+            );
+        case 'NO_VALID_ENTRY':
+            return (
+                <>
+                    <h1>{name},</h1>
+                    <h2>Nemáte žádný dobitý vstup nebo platné předplatné,</h2>
+                    <p>prosím dobijte si kartu u obsluhy</p>
+                </>
+            );
+        default:
+            return null;
+        }
+    };
+
+    return <div className={styles.container}>{renderContent()}</div>;
 }
 
 export default EntryStatusPage;

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -2,12 +2,14 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
-import { osloveni } from 'osloveni';
+import { vocative } from 'czech-vocative'
 import styles from './EntryStatusPage.module.css';
+
 
 function EntryStatusPage() {
     const clientRef = useRef(null);
     const [message, setMessage] = useState(null);
+
 
     useEffect(() => {
         const socketUrl = `${import.meta.env.VITE_BACKEND_URL}/ws-entry`;
@@ -36,7 +38,7 @@ function EntryStatusPage() {
 
     useEffect(() => {
         if (!message) return;
-        const timer = setTimeout(() => setMessage(null), 5000);
+        const timer = setTimeout(() => setMessage(null), 8000);
         return () => clearTimeout(timer);
     }, [message]);
 
@@ -50,7 +52,8 @@ function EntryStatusPage() {
             );
         }
 
-        const name = osloveni(message.firstname || '');
+        const rawVocative = vocative(message.firstname || '')
+        const name = capitalize(rawVocative)
 
         switch (message.status) {
         case 'OK_SUBSCRIPTION':
@@ -83,6 +86,16 @@ function EntryStatusPage() {
     };
 
     return <div className={styles.container}>{renderContent()}</div>;
+}
+
+/**
+ * Vrátí řetězec s velkým prvním písmenem (nebo prázdný řetězec, pokud je input prázdný)
+ * @param {string} s
+ * @returns {string}
+ */
+function capitalize(s) {
+    if (!s) return ''
+    return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 export default EntryStatusPage;

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
@@ -7,3 +7,9 @@
     min-height: 100vh;
     text-align: center;
 }
+
+.chill {
+    font-size: 8vw;
+    font-weight: bold;
+    line-height: 1.1;
+}


### PR DESCRIPTION
## Summary
- show big default message when idle and handle websocket messages for entry status
- add `osloveni` dependency for Czech vocative
- style idle screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d79fcf4c48333a238a77042080120