### PR TITLE
Add EntryStatusMessage component

### DIFF
--- a/gym_managementservice_frontend/src/components/EntryStatusMessage.jsx
+++ b/gym_managementservice_frontend/src/components/EntryStatusMessage.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { vocative } from 'czech-vocative';
+import styles from './EntryStatusMessage.module.css';
+
+function EntryStatusMessage({ message }) {
+    if (!message) {
+        return (
+            <h1 className={styles.chill}>
+                MILANO<br />
+                GYM
+            </h1>
+        );
+    }
+
+    const rawVocative = vocative(message.firstname || '');
+    const name = capitalize(rawVocative);
+
+    let content = null;
+    switch (message.status) {
+    case 'OK_SUBSCRIPTION':
+        content = (
+            <>
+                <h1>Vítejte {name},</h1>
+                <h2>pěkně si zacvičte</h2>
+                <p>Vaše předplatné je aktivní do: {message.expiryDate}</p>
+            </>
+        );
+        break;
+    case 'OK_ONE_TIME_ENTRY':
+        content = (
+            <>
+                <h1>Vítejte {name},</h1>
+                <h2>pěkně si zacvičte</h2>
+                <p>Počet zbývajících vstupů: {message.remainingEntries}</p>
+            </>
+        );
+        break;
+    case 'NO_VALID_ENTRY':
+        content = (
+            <>
+                <h1>{name},</h1>
+                <h2>Nemáte žádný dobitý vstup nebo platné předplatné,</h2>
+                <p>prosím dobijte si kartu u obsluhy</p>
+            </>
+        );
+        break;
+    default:
+        content = null;
+    }
+
+    return <div className={styles.messageContainer}>{content}</div>;
+}
+
+function capitalize(s) {
+    if (!s) return '';
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export default EntryStatusMessage;

--- a/gym_managementservice_frontend/src/components/EntryStatusMessage.module.css
+++ b/gym_managementservice_frontend/src/components/EntryStatusMessage.module.css
@@ -1,0 +1,29 @@
+.messageContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.5rem;
+}
+
+.messageContainer h1 {
+    font-size: 5vw;
+    margin: 0;
+}
+
+.messageContainer h2 {
+    font-size: 3vw;
+    margin: 0;
+}
+
+.messageContainer p {
+    font-size: 2vw;
+    margin: 1rem 0 0;
+}
+
+.chill {
+    font-size: 8vw;
+    font-weight: bold;
+    line-height: 1.1;
+    text-align: center;
+}

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -2,8 +2,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
-import { vocative } from 'czech-vocative'
 import styles from './EntryStatusPage.module.css';
+import EntryStatusMessage from '../components/EntryStatusMessage.jsx';
 
 
 function EntryStatusPage() {
@@ -42,60 +42,11 @@ function EntryStatusPage() {
         return () => clearTimeout(timer);
     }, [message]);
 
-    const renderContent = () => {
-        if (!message) {
-            return (
-                <h1 className={styles.chill}>
-                    MILANO<br />
-                    GYM
-                </h1>
-            );
-        }
-
-        const rawVocative = vocative(message.firstname || '')
-        const name = capitalize(rawVocative)
-
-        switch (message.status) {
-        case 'OK_SUBSCRIPTION':
-            return (
-                <>
-                    <h1>Vítejte {name},</h1>
-                    <h2>pěkně si zacvičte</h2>
-                    <p>Vaše předplatné je aktivní do: {message.expiryDate}</p>
-                </>
-            );
-        case 'OK_ONE_TIME_ENTRY':
-            return (
-                <>
-                    <h1>Vítejte {name},</h1>
-                    <h2>pěkně si zacvičte</h2>
-                    <p>Počet zbývajících vstupů: {message.remainingEntries}</p>
-                </>
-            );
-        case 'NO_VALID_ENTRY':
-            return (
-                <>
-                    <h1>{name},</h1>
-                    <h2>Nemáte žádný dobitý vstup nebo platné předplatné,</h2>
-                    <p>prosím dobijte si kartu u obsluhy</p>
-                </>
-            );
-        default:
-            return null;
-        }
-    };
-
-    return <div className={styles.container}>{renderContent()}</div>;
-}
-
-/**
- * Vrátí řetězec s velkým prvním písmenem (nebo prázdný řetězec, pokud je input prázdný)
- * @param {string} s
- * @returns {string}
- */
-function capitalize(s) {
-    if (!s) return ''
-    return s.charAt(0).toUpperCase() + s.slice(1)
+    return (
+        <div className={styles.container}>
+            <EntryStatusMessage message={message} />
+        </div>
+    );
 }
 
 export default EntryStatusPage;

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.module.css
@@ -8,8 +8,3 @@
     text-align: center;
 }
 
-.chill {
-    font-size: 8vw;
-    font-weight: bold;
-    line-height: 1.1;
-}


### PR DESCRIPTION
## Summary
- add EntryStatusMessage component to display WebSocket info
- style message with large fonts
- use the new component in EntryStatusPage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d8265958083338ce11a175f513cf3