### PR TITLE
Stylish progress bar for entry status messages

### DIFF
--- a/gym_managementservice_frontend/src/components/EntryStatusMessage.jsx
+++ b/gym_managementservice_frontend/src/components/EntryStatusMessage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { vocative } from 'czech-vocative';
 import styles from './EntryStatusMessage.module.css';
 
-function EntryStatusMessage({ message }) {
+function EntryStatusMessage({ message, timeout = 8000 }) {
     if (!message) {
         return (
             <h1 className={styles.chill}>
@@ -48,7 +48,17 @@ function EntryStatusMessage({ message }) {
         content = null;
     }
 
-    return <div className={styles.messageContainer}>{content}</div>;
+    return (
+        <div
+            className={styles.messageContainer}
+            style={{ '--duration': `${timeout}ms` }}
+        >
+            {content}
+            <div className={styles.progressBarContainer}>
+                <div className={styles.progressBar} />
+            </div>
+        </div>
+    );
 }
 
 function capitalize(s) {

--- a/gym_managementservice_frontend/src/components/EntryStatusMessage.module.css
+++ b/gym_managementservice_frontend/src/components/EntryStatusMessage.module.css
@@ -1,23 +1,29 @@
+
 .messageContainer {
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
     gap: 0.5rem;
+    padding: 2rem 3rem;
+    background-color: var(--component-background);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    color: #fff;
 }
 
 .messageContainer h1 {
-    font-size: 5vw;
+    font-size: 6vw;
     margin: 0;
 }
 
 .messageContainer h2 {
-    font-size: 3vw;
+    font-size: 3.5vw;
     margin: 0;
 }
 
 .messageContainer p {
-    font-size: 2vw;
+    font-size: 2.2vw;
     margin: 1rem 0 0;
 }
 
@@ -26,4 +32,29 @@
     font-weight: bold;
     line-height: 1.1;
     text-align: center;
+}
+
+.progressBarContainer {
+    width: 100%;
+    height: 0.5rem;
+    background-color: rgba(255, 255, 255, 0.2);
+    margin-top: 1rem;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.progressBar {
+    width: 100%;
+    height: 100%;
+    background-color: var(--button-background);
+    animation: countdown var(--duration, 8000ms) linear forwards;
+}
+
+@keyframes countdown {
+    from {
+        width: 100%;
+    }
+    to {
+        width: 0;
+    }
 }

--- a/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
+++ b/gym_managementservice_frontend/src/pages/EntryStatusPage.jsx
@@ -6,6 +6,8 @@ import styles from './EntryStatusPage.module.css';
 import EntryStatusMessage from '../components/EntryStatusMessage.jsx';
 
 
+const MESSAGE_TIMEOUT = 8000; // how long to show the message in ms
+
 function EntryStatusPage() {
     const clientRef = useRef(null);
     const [message, setMessage] = useState(null);
@@ -38,13 +40,13 @@ function EntryStatusPage() {
 
     useEffect(() => {
         if (!message) return;
-        const timer = setTimeout(() => setMessage(null), 8000);
+        const timer = setTimeout(() => setMessage(null), MESSAGE_TIMEOUT);
         return () => clearTimeout(timer);
     }, [message]);
 
     return (
         <div className={styles.container}>
-            <EntryStatusMessage message={message} />
+            <EntryStatusMessage message={message} timeout={MESSAGE_TIMEOUT} />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- create a constant timeout for `EntryStatusPage` and pass it to message component
- rework `EntryStatusMessage` to accept timeout and show a progress bar
- add modern styling for the message container and countdown bar

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d86e78ac4833387e944544a8820aa