### PR TITLE
Implement user identification for ManualCharge

### DIFF
--- a/gym_managementservice_frontend/src/pages/ManualCharge.jsx
+++ b/gym_managementservice_frontend/src/pages/ManualCharge.jsx
@@ -8,9 +8,10 @@ import { chargeOneTimeEntry, MANUAL_ENTRY_ID } from '../utils/oneTimeEntryUtils'
 
 import UserInfoBox from '../components/UserInfoBox';
 import SimpleButton from '../components/SimpleButton';
+import UserIdentifier from '../components/UserIdentifier';
 
 function ManualCharge() {
-    const userId = 1;
+    const [userId, setUserId] = useState(null);
     const {
         user,
         hasActiveSubscription,
@@ -28,6 +29,10 @@ function ManualCharge() {
     useEffect(() => {
         if (error) toast.error(error);
     }, [error]);
+
+    if (!userId) {
+        return <UserIdentifier onUserFound={setUserId} mode="multiple" />;
+    }
 
     const handleConfirm = async () => {
         if (!customEndDate) {


### PR DESCRIPTION
## Summary
- add UserIdentifier to ManualCharge page
- let user id be selected via card reader before manual charge page loads

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fa71011d08333b1dce6eadf260daf