### PR TITLE
Add stats to cards & unify user info props

### DIFF
--- a/gym_managementservice_frontend/src/components/UserCard.jsx
+++ b/gym_managementservice_frontend/src/components/UserCard.jsx
@@ -27,7 +27,9 @@ function UserCard({ user }) {
         lastname,
         profilePhotoPath,
         subscriptions = [],
-        lastEntryDate
+        lastEntryDate,
+        oneTimeCount,
+        points
     } = user;
 
     const navigate = useNavigate();
@@ -142,6 +144,11 @@ function UserCard({ user }) {
                 <p className={styles.lastEntry}>
                     Poslední vstup: <strong>{lastEntryDate ? formatDate(lastEntryDate) : 'Žádný vstup'}</strong>
                 </p>
+
+                <div className={styles.stats}>
+                    <p>Vstupy: <strong>{oneTimeCount ?? '-'}</strong></p>
+                    <p>Body: <strong>{points ?? '-'}</strong></p>
+                </div>
             </div>
         </div>
     );
@@ -156,6 +163,8 @@ UserCard.propTypes = {
         profilePhotoPath: PropTypes.string,
         subscriptions: PropTypes.array,
         lastEntryDate: PropTypes.string,
+        oneTimeCount: PropTypes.number,
+        points: PropTypes.number,
     }).isRequired,
 };
 

--- a/gym_managementservice_frontend/src/components/UserCard.module.css
+++ b/gym_managementservice_frontend/src/components/UserCard.module.css
@@ -108,6 +108,14 @@
     font-size: 0.9rem;
 }
 
+/* Statistické údaje */
+.stats {
+    margin: 4px 0;
+    font-size: 0.9rem;
+    display: flex;
+    gap: 1rem;
+}
+
 /* Hover efekt u data posledního vstupu */
 .lastEntry:hover {
     color: var(--backgroud-color);

--- a/gym_managementservice_frontend/src/components/UserInfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.jsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import styles from './UserInfoBox.module.css';
 
-function UserInfoBox({
-                         id,
-                         firstname,
-                         lastname,
-                         email,
-                         birthdate,
-                         profilePhoto,
-                         hasActiveSubscription,
-                         latestSubscription,
-                         isExpiredSubscription,
-                         oneTimeCount,
-                        points,
-                     }) {
+function UserInfoBox({ info }) {
+    const {
+        id,
+        firstname,
+        lastname,
+        email,
+        birthdate,
+        profilePhoto,
+        hasActiveSubscription,
+        latestSubscription,
+        isExpiredSubscription,
+        oneTimeCount,
+        points,
+    } = info || {};
     const formatDate = (dateObj) => {
         if (!dateObj) return '-';
         return dateObj.toLocaleDateString('cs-CZ', {

--- a/gym_managementservice_frontend/src/components/UserInfoBox.module.css
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.module.css
@@ -62,3 +62,8 @@
     color: #ff6b6b; /* červená */
     margin-top: 0.5rem;
 }
+
+.oneTimeCount,
+.points {
+    margin-top: 0.5rem;
+}

--- a/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
@@ -153,6 +153,20 @@ function ChargeSubscription() {
         setIsModalOpen(false);
     };
 
+    const userInfo = user ? {
+        id: userId,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        email: user.email,
+        birthdate: user.birthdate,
+        profilePhoto: user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null,
+        hasActiveSubscription,
+        latestSubscription,
+        isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),
+        oneTimeCount,
+        points: user.points,
+    } : null;
+
     // Nejprve požádáme o číslo karty, dokud nemáme userId
     if (!userId) {
         return <UserIdentifier onUserFound={setUserId} />;
@@ -180,20 +194,7 @@ function ChargeSubscription() {
                 <div className={styles.mainContent}>
                     {/* Levý sloupec: info o uživateli */}
                     <div className={styles.leftColumn}>
-                        <UserInfoBox
-                            id={userId}
-                            firstname={user.firstname}
-                            lastname={user.lastname}
-                            email={user.email}
-                            birthdate={user.birthdate}
-                            profilePhoto={user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null}
-                            hasActiveSubscription={hasActiveSubscription}
-                            latestSubscription={latestSubscription}
-                            isExpiredSubscription={
-                                latestSubscription && new Date(latestSubscription.endDate) < new Date()
-                            }
-                            oneTimeCount={oneTimeCount}
-                        />
+                        <UserInfoBox info={userInfo} />
 
                         {/* Checkbox "Je student?" */}
                         <div className={styles.studentCheckboxContainer}>

--- a/gym_managementservice_frontend/src/pages/ManualCharge.jsx
+++ b/gym_managementservice_frontend/src/pages/ManualCharge.jsx
@@ -34,6 +34,20 @@ function ManualCharge() {
         return <UserIdentifier onUserFound={setUserId} mode="multiple" />;
     }
 
+    const userInfo = user ? {
+        id: userId,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        email: user.email,
+        birthdate: user.birthdate,
+        profilePhoto: user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null,
+        hasActiveSubscription,
+        latestSubscription,
+        isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),
+        oneTimeCount,
+        points: user.points,
+    } : null;
+
     const handleConfirm = async () => {
         if (!customEndDate) {
             toast.warn('Zadejte datum konce.');
@@ -90,20 +104,7 @@ function ManualCharge() {
             <div className={styles.columns}>
                 {user && (
                     <div className={styles.infoColumn}>
-                        <UserInfoBox
-                            id={userId}
-                            firstname={user.firstname}
-                            lastname={user.lastname}
-                            email={user.email}
-                            birthdate={user.birthdate}
-                            profilePhoto={user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null}
-                            hasActiveSubscription={hasActiveSubscription}
-                            latestSubscription={latestSubscription}
-                            isExpiredSubscription={
-                                latestSubscription && new Date(latestSubscription.endDate) < new Date()
-                            }
-                            oneTimeCount={oneTimeCount}
-                        />
+                        <UserInfoBox info={userInfo} />
                     </div>
                 )}
 

--- a/gym_managementservice_frontend/src/pages/UserDetail.jsx
+++ b/gym_managementservice_frontend/src/pages/UserDetail.jsx
@@ -65,25 +65,25 @@ export default function UserDetail() {
         setShowAssignCard(prev => !prev);
     };
 
+    const userInfo = {
+        id: +userId,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        email: user.email,
+        birthdate: user.birthdate,
+        profilePhoto: user.profilePhoto,
+        hasActiveSubscription,
+        latestSubscription,
+        isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),
+        oneTimeCount,
+        points: user.points,
+    };
+
     return (
         <div className={styles.userDetailContainer}>
             {/* LEVÁ STRANA */}
             <div className={styles.leftSide}>
-                <UserInfoBox
-                    id={+userId}
-                    firstname={user.firstname}
-                    lastname={user.lastname}
-                    email={user.email}
-                    birthdate={user.birthdate}
-                    profilePhoto={user.profilePhoto}
-                    hasActiveSubscription={hasActiveSubscription}
-                    latestSubscription={latestSubscription}
-                    isExpiredSubscription={
-                        latestSubscription && new Date(latestSubscription.endDate) < new Date()
-                    }
-                    oneTimeCount={oneTimeCount}
-                    points={user.points}
-                />
+                <UserInfoBox info={userInfo} />
                 {/* SPODNÍ ŘÁDEK – STATISTIKY */}
                 <div className={styles.statsContainer}>
                     <div className={styles.statCard}>


### PR DESCRIPTION
## Summary
- refactor `UserInfoBox` to accept a single `info` object
- show one-time entry count and points in `UserCard`
- style new stats sections
- pass unified props from pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fadb74c588333ac5d3c4544225897