### PR TITLE
Implement InfoBox for user stats

### DIFF
--- a/gym_managementservice_frontend/src/components/InfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/InfoBox.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './InfoBox.module.css';
+
+function InfoBox({ label, value }) {
+    return (
+        <div className={styles.infoBox}>
+            <span className={styles.value}>{value}</span>
+            <span className={styles.label}>{label}</span>
+        </div>
+    );
+}
+
+InfoBox.propTypes = {
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+export default InfoBox;

--- a/gym_managementservice_frontend/src/components/InfoBox.module.css
+++ b/gym_managementservice_frontend/src/components/InfoBox.module.css
@@ -1,0 +1,23 @@
+.infoBox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--component-background);
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    min-width: 5rem;
+}
+
+.value {
+    font-size: 1.3rem;
+    font-weight: bold;
+}
+
+.label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: #ccc;
+}

--- a/gym_managementservice_frontend/src/components/UserInfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './UserInfoBox.module.css';
+import InfoBox from './InfoBox';
 
 function UserInfoBox({ info }) {
     const {
@@ -64,11 +65,10 @@ function UserInfoBox({ info }) {
                     <p className={styles.noSubscription}><strong>Žádné aktivní předplatné.</strong></p>
                 )}
 
-                {/* Nový údaj o jednorázových vstupů */}
-                <p className={styles.oneTimeCount}>
-                    Počet jednorázovcýh vstupů: {oneTimeCount}
-                </p>
-                <p><strong>Body: </strong>{points}</p>
+                <div className={styles.statsContainer}>
+                    <InfoBox label="Vstupy" value={oneTimeCount ?? 0} />
+                    <InfoBox label="Body" value={points ?? 0} />
+                </div>
             </div>
         </div>
     );

--- a/gym_managementservice_frontend/src/components/UserInfoBox.module.css
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.module.css
@@ -63,7 +63,8 @@
     margin-top: 0.5rem;
 }
 
-.oneTimeCount,
-.points {
+.statsContainer {
+    display: flex;
+    gap: 1rem;
     margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add InfoBox component
- style InfoBox for metric tiles
- use InfoBox inside UserInfoBox to show one-time entry count and points
- update UserInfoBox styles for the new layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687023294c8c8333b220b1fb1cd9a2e0