### PR TITLE
Handle quality when fetching profile photos

### DIFF
--- a/gym_managementservice_frontend/src/components/UserCard.jsx
+++ b/gym_managementservice_frontend/src/components/UserCard.jsx
@@ -1,13 +1,12 @@
 // src/components/UserCard.jsx
-import React, {useMemo, useCallback, useEffect, useRef, useState} from 'react';
+import React, { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import styles from './UserCard.module.css';
 import { getActiveSubscription } from '../utils/subscriptionUtils.js';
 import { formatDate } from '../utils/dateUtils.js';
+import { buildProfilePhotoUrl, ProfilePhotoQuality } from '../utils/photoUtils.js';
 
-// Základní URL získaná z environmentální proměnné (Vite) nebo fallback hodnota.
-const BASE_API_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 
 /**
  * Komponenta UserCard
@@ -58,9 +57,10 @@ function UserCard({ user }) {
     }, [activeSubscription]);
 
     /**
-     * Sestavení URL pro načtení profilové fotografie.
+     * Sestavení URL pro načtení profilové fotografie s nižší kvalitou,
+     * aby byl seznam uživatelů načítán rychleji.
      */
-    const photoUrl = profilePhotoPath ? `${BASE_API_URL}${profilePhotoPath}` : null;
+    const photoUrl = buildProfilePhotoUrl(profilePhotoPath, ProfilePhotoQuality.LOW);
 
 
     // Ref a stav pro sledování viditelnosti karty

--- a/gym_managementservice_frontend/src/components/UserInfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styles from './UserInfoBox.module.css';
 import InfoBox from './InfoBox';
+import { buildProfilePhotoUrl, ProfilePhotoQuality } from '../utils/photoUtils.js';
 
 function UserInfoBox({ info }) {
     const {
@@ -9,7 +10,7 @@ function UserInfoBox({ info }) {
         lastname,
         email,
         birthdate,
-        profilePhoto,
+        profilePhotoPath,
         hasActiveSubscription,
         latestSubscription,
         isExpiredSubscription,
@@ -25,15 +26,16 @@ function UserInfoBox({ info }) {
         });
     };
 
-    // Sestavení URL pro profilovou fotku pomocí .env proměnné
-    const profilePhotoUrl = profilePhoto
-        ? `http://localhost:8080/api/users/${id}/profilePhoto`
-        : null;
+    // Sestavení URL pro profilovou fotku v nejvyšší kvalitě
+    const profilePhotoUrl = buildProfilePhotoUrl(
+        profilePhotoPath || `/api/users/${id}/profilePhoto`,
+        ProfilePhotoQuality.HIGH
+    );
 
     return (
         <div className={styles.userInfoBox}>
             <div className={styles.photoContainer}>
-                {profilePhoto ? (
+                {profilePhotoUrl ? (
                     <img
                         src={profilePhotoUrl}
                         alt={`${firstname} ${lastname}`}

--- a/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
@@ -159,7 +159,7 @@ function ChargeSubscription() {
         lastname: user.lastname,
         email: user.email,
         birthdate: user.birthdate,
-        profilePhoto: user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null,
+        profilePhotoPath: user.profilePhoto ? `/api/users/${userId}/profilePhoto` : null,
         hasActiveSubscription,
         latestSubscription,
         isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),

--- a/gym_managementservice_frontend/src/pages/ManualCharge.jsx
+++ b/gym_managementservice_frontend/src/pages/ManualCharge.jsx
@@ -52,7 +52,7 @@ function ManualCharge() {
         lastname: user.lastname,
         email: user.email,
         birthdate: user.birthdate,
-        profilePhoto: user.profilePhoto ? `/profile-photos/${user.profilePhoto}` : null,
+        profilePhotoPath: user.profilePhoto ? `/api/users/${userId}/profilePhoto` : null,
         hasActiveSubscription,
         latestSubscription,
         isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),

--- a/gym_managementservice_frontend/src/pages/UserDetail.jsx
+++ b/gym_managementservice_frontend/src/pages/UserDetail.jsx
@@ -71,7 +71,7 @@ export default function UserDetail() {
         lastname: user.lastname,
         email: user.email,
         birthdate: user.birthdate,
-        profilePhoto: user.profilePhoto,
+        profilePhotoPath: user.profilePhoto ? `/api/users/${userId}/profilePhoto` : null,
         hasActiveSubscription,
         latestSubscription,
         isExpiredSubscription: latestSubscription && new Date(latestSubscription.endDate) < new Date(),

--- a/gym_managementservice_frontend/src/utils/photoUtils.js
+++ b/gym_managementservice_frontend/src/utils/photoUtils.js
@@ -1,0 +1,18 @@
+export const ProfilePhotoQuality = {
+    LOW: 'LOW',
+    MEDIUM: 'MEDIUM',
+    HIGH: 'HIGH'
+};
+
+/**
+ * Builds full URL to fetch a profile photo with desired quality.
+ * @param {string} profilePhotoPath - Path returned from API (e.g. `/api/users/5/profilePhoto`).
+ * @param {string} quality - One of 'LOW', 'MEDIUM', 'HIGH'. Defaults to 'HIGH'.
+ * @returns {string|null} Full URL or null if path is not provided.
+ */
+export function buildProfilePhotoUrl(profilePhotoPath, quality = ProfilePhotoQuality.HIGH) {
+    if (!profilePhotoPath) return null;
+    const baseUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
+    const separator = profilePhotoPath.includes('?') ? '&' : '?';
+    return `${baseUrl}${profilePhotoPath}${separator}quality=${quality}`;
+}


### PR DESCRIPTION
## Summary
- add `photoUtils.js` for constructing profile photo URLs with quality parameter
- show low quality pictures in user card list
- fetch high quality photo in user info box
- update manual charge, subscription and detail pages to use `profilePhotoPath`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68714ce961288333bb3a4b9b42cabde9