### PR TITLE
Move profile photo upload into user info

### DIFF
--- a/gym_managementservice_frontend/src/App.jsx
+++ b/gym_managementservice_frontend/src/App.jsx
@@ -47,6 +47,7 @@ function App() {
                     <Route path="/" element={<HomePage />} />
                     <Route path="/RegisterUser" element={<RegisterUser />} />
                     <Route path="/ChargeUser" element={<ChargeSubscription />} />
+                    <Route path="/ChargeUser/:id" element={<ChargeSubscription />} />
                     <Route path="/searchUser" element={<SearchUser />} />
                     <Route path="/closure" element={<ClosurePage />} />
                     <Route path="/users/allUsers" element={<AllUsers />} />

--- a/gym_managementservice_frontend/src/components/UserInfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.jsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './UserInfoBox.module.css';
 import InfoBox from './InfoBox';
+import SimpleButton from './SimpleButton';
+import UploadProfilePhoto from './UploadProfilePhoto';
 import { buildProfilePhotoUrl, ProfilePhotoQuality } from '../utils/photoUtils.js';
 
 function UserInfoBox({ info }) {
@@ -27,17 +29,30 @@ function UserInfoBox({ info }) {
     };
 
     // Sestavení URL pro profilovou fotku v nejvyšší kvalitě
-    const profilePhotoUrl = buildProfilePhotoUrl(
-        profilePhotoPath || `/api/users/${id}/profilePhoto`,
-        ProfilePhotoQuality.HIGH
+    const [photoUrl, setPhotoUrl] = useState(() =>
+        buildProfilePhotoUrl(
+            profilePhotoPath || `/api/users/${id}/profilePhoto`,
+            ProfilePhotoQuality.HIGH
+        )
     );
+
+    const [showUpload, setShowUpload] = useState(false);
+
+    const handleUploadSuccess = () => {
+        const newUrl = buildProfilePhotoUrl(
+            profilePhotoPath || `/api/users/${id}/profilePhoto`,
+            ProfilePhotoQuality.HIGH
+        ) + `?t=${Date.now()}`;
+        setPhotoUrl(newUrl);
+        setShowUpload(false);
+    };
 
     return (
         <div className={styles.userInfoBox}>
             <div className={styles.photoContainer}>
-                {profilePhotoUrl ? (
+                {photoUrl ? (
                     <img
-                        src={profilePhotoUrl}
+                        src={photoUrl}
                         alt={`${firstname} ${lastname}`}
                         className={styles.profilePhoto}
                         onError={(e) => {
@@ -50,6 +65,14 @@ function UserInfoBox({ info }) {
                     <div className={styles.placeholderPhoto}>Bez fotky</div>
                 )}
             </div>
+            {showUpload ? (
+                <UploadProfilePhoto userId={id} onSuccess={handleUploadSuccess} />
+            ) : (
+                <SimpleButton
+                    text="Nahrát novou fotografii"
+                    onClick={() => setShowUpload(true)}
+                />
+            )}
 
             <div className={styles.infoContainer}>
                 <h3>

--- a/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
+++ b/gym_managementservice_frontend/src/pages/ChargeSubscription.jsx
@@ -3,6 +3,7 @@
  * Stránka pro dobití předplatného a jednorázových vstupů uživatele.
  */
 import React, { useEffect, useState, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import styles from './ChargeSubscription.module.css';
 
@@ -18,8 +19,9 @@ import SubscriptionSection from '../components/SubscriptionSection';
 import UserIdentifier from '../components/UserIdentifier';
 
 function ChargeSubscription() {
-    // ID uživatele bude získáno z modálního okna
-    const [userId, setUserId] = useState(null);
+    const { id } = useParams();
+    // ID uživatele bude získáno z URL nebo z modálního okna
+    const [userId, setUserId] = useState(id || null);
 
     // Custom hook, který stáhne vše potřebné
     const {

--- a/gym_managementservice_frontend/src/pages/UserDetail.jsx
+++ b/gym_managementservice_frontend/src/pages/UserDetail.jsx
@@ -60,7 +60,9 @@ export default function UserDetail() {
     const handleShowHistory = () => {
         navigate(`/users/${userId}/history`);
     };
-    const handleCharge       = () => { /* ... */ };
+    const handleCharge       = () => {
+        navigate(`/ChargeUser/${userId}`);
+    };
     const handleAssignCard   = () => {
         setShowAssignCard(prev => !prev);
     };
@@ -114,11 +116,6 @@ export default function UserDetail() {
                         text="Přiřadit kartu"
                         onClick={handleAssignCard}
                         ariaLabel="Přiřadit kartu uživateli"
-                    />
-                    <AnimatedButton
-                        text="Nahrát novou fotografii"
-                        onClick={handleAssignCard}
-                        ariaLabel="Nahrát uživateli novou profilovou fotku"
                     />
                     {showAssignCard && (
                         <UploadUserCard userId={+userId} />


### PR DESCRIPTION
## Summary
- allow UserInfoBox to show upload button and UploadProfilePhoto component
- navigate from UserDetail directly to ChargeSubscription with user ID
- support user ID in ChargeSubscription via route param
- add route `/ChargeUser/:id` for direct subscription charging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68725d53f5c083339c053de828952f68