### PR TITLE
Add cancel option to profile photo upload

### DIFF
--- a/gym_managementservice_frontend/src/components/UploadProfilePhoto.jsx
+++ b/gym_managementservice_frontend/src/components/UploadProfilePhoto.jsx
@@ -15,8 +15,10 @@ import SimpleButton from './SimpleButton';
  * @param {Object} props - Vlastnosti komponenty.
  * @param {number} props.userId - ID uživatele, jehož profilová fotografie se nahrává.
  * @param {function} [props.onSuccess] - Callback vyvolaný po úspěšném nahrání.
+ * @param {boolean} [props.showCancel=false] - Zda zobrazit tlačítko pro zrušení nahrávání.
+ * @param {function} [props.onCancel] - Callback vyvolaný po kliknutí na "Zrušit".
 */
-const UploadProfilePhoto = ({ userId, onSuccess }) => {
+const UploadProfilePhoto = ({ userId, onSuccess, showCancel = false, onCancel }) => {
     const [file, setFile] = useState(null);
     const [preview, setPreview] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
@@ -236,6 +238,13 @@ const UploadProfilePhoto = ({ userId, onSuccess }) => {
                 type="button"
                 disabled={isLoading} // Zabránění vícenásobnému kliknutí během nahrávání
             />
+            {showCancel && (
+                <SimpleButton
+                    text="Zrušit"
+                    onClick={onCancel}
+                    type="button"
+                />
+            )}
         </div>
     );
 };

--- a/gym_managementservice_frontend/src/components/UserInfoBox.jsx
+++ b/gym_managementservice_frontend/src/components/UserInfoBox.jsx
@@ -68,7 +68,12 @@ function UserInfoBox({ info }) {
                 </div>
                 <div className={styles.uploadPhoto}>
                     {showUpload ? (
-                        <UploadProfilePhoto userId={id} onSuccess={handleUploadSuccess} />
+                        <UploadProfilePhoto
+                            userId={id}
+                            onSuccess={handleUploadSuccess}
+                            showCancel
+                            onCancel={() => setShowUpload(false)}
+                        />
                     ) : (
                         <SimpleButton
                             text="Nahrát novou fotografii"


### PR DESCRIPTION
## Summary
- enhance UploadProfilePhoto to optionally show a cancel button
- wire cancel button in UserInfoBox

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68726326f5a08333a4afe6eec5de73b0