### PR TITLE
Fix card reader handling

### DIFF
--- a/gym_managementservice_frontend/src/components/UserIdentifier.jsx
+++ b/gym_managementservice_frontend/src/components/UserIdentifier.jsx
@@ -37,7 +37,6 @@ function UserIdentifier({ onUserFound, mode = 'multiple' }) {
 
         socket.onerror = (err) => {
             console.error('WS chyba', err);
-            toast.error('Chyba spojení s čtečkou.');
         };
 
         return () => {
@@ -53,7 +52,11 @@ function UserIdentifier({ onUserFound, mode = 'multiple' }) {
 
         setLoading(true);
         try {
-            const response = await api.get(`/users/byCardNumber/${num}`);
+            const cardNumInt = parseInt(num, 10);
+            if (Number.isNaN(cardNumInt)) {
+                throw new Error('Invalid card number');
+            }
+            const response = await api.get(`/users/byCardNumber/${cardNumInt}`);
             const { status, userID } = response.data;
 
             if (mode === 'single') {


### PR DESCRIPTION
## Summary
- handle card reader ID as integer when querying backend
- remove misleading toast error for card reader connection

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6873e03778108333b8a83f005a6898f3