### PR TITLE
Enable websocket scanning for cards

### DIFF
--- a/gym_managementservice_frontend/src/components/UploadUserCard.jsx
+++ b/gym_managementservice_frontend/src/components/UploadUserCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { toast } from 'react-toastify';
 import api from '../services/api.js';
@@ -8,16 +8,57 @@ import styles from './UploadUserCard.module.css';
 function UploadUserCard({ userId, onSuccess }) {
     const [cardNumber, setCardNumber] = useState('');
     const [loading, setLoading] = useState(false);
+    const wsRef = useRef(null);
+    const loadingRef = useRef(false);
 
-    const handleAssign = async () => {
-        if (!cardNumber) {
-            toast.warning('Nejdříve zadejte číslo karty.');
+    useEffect(() => {
+        loadingRef.current = loading;
+    }, [loading]);
+
+    useEffect(() => {
+        const wsUrl = import.meta.env.VITE_CARD_READER_WS_URL || 'ws://192.168.55.205:81/';
+        const socket = new WebSocket(wsUrl);
+        wsRef.current = socket;
+
+        socket.onopen = () => {
+            console.log('WebSocket opened');
+            socket.send('START');
+        };
+
+        socket.onmessage = (e) => {
+            if (loadingRef.current) return;
+            const uid = e.data?.trim();
+            if (!uid) return;
+            setCardNumber(uid);
+            handleAssign(uid);
+        };
+
+        socket.onerror = (err) => {
+            console.error('WebSocket error', err);
+            toast.error('Chyba WebSocket připojení.');
+        };
+
+        socket.onclose = () => {
+            console.log('WebSocket closed');
+        };
+
+        return () => {
+            if (wsRef.current?.readyState === WebSocket.OPEN) {
+                wsRef.current.send('STOP');
+            }
+            wsRef.current?.close();
+        };
+    }, [userId]);
+
+    const handleAssign = async (number = cardNumber) => {
+        if (!number) {
+            toast.warning('Nejdříve přilož kartu.');
             return;
         }
 
         setLoading(true);
         try {
-            await api.post(`/users/${userId}/assignCard`, { cardNumber });
+            await api.post(`/users/${userId}/assignCard`, { cardNumber: number });
             toast.success('Karta úspěšně přiřazena!');
             setCardNumber('');
             onSuccess();
@@ -30,7 +71,7 @@ function UploadUserCard({ userId, onSuccess }) {
 
     return (
         <div className={styles.uploadCardContainer}>
-            <h3>Přiřaď svou členskou kartu</h3>
+            <h3>Přilož členskou kartu ke čtečce</h3>
             <div className={styles.formGroup}>
                 <label htmlFor="cardNumber">Číslo karty</label>
                 <input
@@ -43,7 +84,7 @@ function UploadUserCard({ userId, onSuccess }) {
             </div>
             <SimpleButton
                 text={loading ? 'Ukládám...' : 'Přiřadit'}
-                onClick={handleAssign}
+                onClick={() => handleAssign()}
                 disabled={loading}
             />
         </div>


### PR DESCRIPTION
## Summary
- add websocket logic to `UploadUserCard` similar to `UserIdentifier`
- automatically assign card when UID arrives from the reader

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873e8a94cd08333ba451d5aa5223cf8