### PR TITLE
Add terms agreement checkbox

### DIFF
--- a/gym_managementservice_frontend/src/components/RegistrationForm.jsx
+++ b/gym_managementservice_frontend/src/components/RegistrationForm.jsx
@@ -213,6 +213,25 @@ export default function RegistrationForm() {
                         )}
                     </div>
 
+                    <div className={styles.formGroup}>
+                        <label htmlFor="terms" className={styles.checkboxLabel}>
+                            <input
+                                id="terms"
+                                type="checkbox"
+                                {...register('terms', {
+                                    required: 'Musíte souhlasit se zpracováním osobních údajů a smluvními podmínkami'
+                                })}
+                            />
+                            <span>
+                                Souhlasím se zpracováním osobních údajů a{' '}
+                                <a href="/smluvni_podminky.txt" target="_blank" rel="noopener noreferrer">
+                                    smluvními podmínkami
+                                </a>
+                            </span>
+                        </label>
+                        {errors.terms && <p className={styles.error}>{errors.terms.message}</p>}
+                    </div>
+
                     <SimpleButton
                         text={loading ? 'Probíhá registrace...' : 'Registrovat'}
                         type="submit"

--- a/gym_managementservice_frontend/src/components/RegistrationForm.module.css
+++ b/gym_managementservice_frontend/src/components/RegistrationForm.module.css
@@ -87,6 +87,17 @@
     outline: none;
 }
 
+/* Skupina pro zaškrtávací políčko s podmínkami */
+.checkboxLabel {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.checkboxLabel input {
+    margin: 0;
+}
+
 .error {
     color: #ff6b6b;
     font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- add required consent checkbox for personal data processing and terms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687417c3d7ec8333b54b3dedb384e7b4